### PR TITLE
Remove undocumented netnod server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |oregon.time.system76.com|2|US|System76||
 |virginia.time.system76.com|2|US|System76||
 ||
-|nts.ntp.se|1|Sweden|Netnod|
 |nts.netnod.se|1|Sweden|Netnod|Anycast|
 |sth1.nts.netnod.se|1|Sweden|Netnod||
 |sth1.nts.netnod.se|1|Sweden|Netnod||

--- a/chrony.conf
+++ b/chrony.conf
@@ -11,7 +11,6 @@ server ohio.time.system76.com nts iburst
 server oregon.time.system76.com nts iburst
 
 # Netnod (Sweden)
-server nts.ntp.se:4443 nts
 server nts.netnod.se:4460 nts iburst # Anycast
 server sth1.nts.netnod.se:4460 nts iburst # Stockholm 
 server sth2.nts.netnod.se:4460 nts iburst # Stockholm


### PR DESCRIPTION
I believe this server was used as a development server by Netnod early on, which is the reason for the non-standard NTS Key Exchange port. However, this has since been removed from the list of public servers:
https://www.netnod.se/nts/network-time-security