### PR TITLE
Fix chrony config parse errors

### DIFF
--- a/chrony.conf
+++ b/chrony.conf
@@ -36,9 +36,9 @@ server ntppool2.time.nl nts iburst
 server ntpmon.dcs1.biz nts iburst
 
 # Netnod (Sweden)
-server nts.netnod.se:4460 nts iburst # Anycast
-server sth1.nts.netnod.se:4460 nts iburst # Stockholm 
-server sth2.nts.netnod.se:4460 nts iburst # Stockholm
+server nts.netnod.se:4460 nts iburst
+server sth1.nts.netnod.se:4460 nts iburst
+server sth2.nts.netnod.se:4460 nts iburst
 
 # Switzerland
 server ntp.3eck.net nts iburst


### PR DESCRIPTION
Comments in the chrony config file can only be on their own line.