### PR TITLE
chrony.conf: specify Cloudflare as pool of 2 servers

### DIFF
--- a/chrony.conf
+++ b/chrony.conf
@@ -3,7 +3,7 @@
 #
 
 # Cloudflare (Anycast)
-server time.cloudflare.com nts iburst
+pool time.cloudflare.com nts iburst maxsources 2
 
 # NTP.br (Brazil)
 server a.st1.ntp.br nts iburst


### PR DESCRIPTION
`time.cloudflare.com` always returns 2 IPv4 and 2 IPv6 addresses for me, so I have decided it to be a pool instead of just a server.

I don't know how correct this is and would be happy to receive feedback.

```
% chronyc -N sources
MS Name/IP address         Stratum Poll Reach LastRx Last sample               
===============================================================================
...
^+ time.cloudflare.com           3   6   377    31   -140us[ -140us] +/-   13ms
^+ time.cloudflare.com           3   6   377    32   -279us[ -279us] +/-   14ms
...
```

```
% chronyc -N authdata
Name/IP address             Mode KeyID Type KLen Last Atmp  NAK Cook CLen
=========================================================================
...
time.cloudflare.com          NTS     1   15  256  469    0    0    8  100
time.cloudflare.com          NTS     6   15  256   4d    0    0    8  100
...
```