### PR TITLE
new proposition to add NTS ntp.viarouge.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |time.bolha.one|1|Brazil|Cadu Silva||
 ||
 |paris.time.system76.com|2|France|System76||
+|ntp.viarouge.net|2|France|Hubert Viarouge|see http://ntp.viarouge.net|
 ||
 |ntp3.fau.de|1|Germany|FAU||
 |ntp3.ipv6.fau.de|1|Germany|FAU|IPv6 only|

--- a/chrony.conf
+++ b/chrony.conf
@@ -66,3 +66,7 @@ server brazil.time.system76.com nts iburst
 server stratum1.time.cifelli.xyz nts iburst
 server time.cifelli.xyz nts iburst
 server time.txryan.com nts iburst
+
+# France
+server ntp.viarouge.net nts iburst
+


### PR DESCRIPTION
Hello,
new proposition to add my NTS server.
I have switched the server from NTPsec to chrony some days ago and it seems to work well (from Paris to Nancy):

chronyd -Q -t 3 'server ntp.viarouge.net iburst nts maxsamples 1'
2023-07-26T09:02:10Z chronyd version 4.3 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +NTS +SECHASH +IPV6 -DEBUG)
2023-07-26T09:02:10Z Disabled control of system clock
2023-07-26T09:02:13Z System clock wrong by -0.000153 seconds (ignored)
2023-07-26T09:02:13Z chronyd exiting

MS Name/IP address         Stratum Poll Reach LastRx Last sample               
===============================================================================
^+ ntp.viarouge.net              2   6   377    57    -26us[  -89us] +/-   17ms
^* tristate.trifence.ch          2   6   377    57    -14us[  -77us] +/-   11ms
^- ntp3.rrze.uni-erlangen.de     1   7    21   242  -5160us[-5232us] +/-   14ms


