### PR TITLE
add ptb server 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Pull requests are welcome to add new sources. Each PR should include any propose
 |ptbtime1.ptb.de|1|Germany|PTB||
 |ptbtime2.ptb.de|1|Germany|PTB||
 |ptbtime3.ptb.de|1|Germany|PTB||
+|ptbtime4.ptb.de|1|Germany|PTB||
 |www.jabber-germany.de|2|Germany|Jörg Morbitzer||
 |www.masters-of-cloud.de|2|Germany|Jörg Morbitzer||
 |ntp-by.dynu.net|1|Germany|Michael Byczkowski||

--- a/chrony.conf
+++ b/chrony.conf
@@ -23,6 +23,7 @@ server ntp3.ipv6.fau.de nts iburst
 server ptbtime1.ptb.de nts iburst
 server ptbtime2.ptb.de nts iburst
 server ptbtime3.ptb.de nts iburst
+server ptbtime4.ptb.de nts iburst
 
 # Germany
 server www.jabber-germany.de nts iburst


### PR DESCRIPTION
The time server ptbtime4.ptb.de was set up at a separate location from the other time servers of the PTB to improve the reliability of time distribution.