### PR TITLE
Add nts.ntstime.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Generally, virtualized systems do not make for good time sources as there is too
 |www.jabber-germany.de|2|Germany|Jörg Morbitzer||
 |www.masters-of-cloud.de|2|Germany|Jörg Morbitzer||
 |ntp-by.dynu.net|1|Germany|Michael Byczkowski||
+|[nts.ntstime.de](https://nts.ntstime.de/)|2|Germany|Patrick Jansen||
 ||
 |ntppool1.time.nl|1|Netherlands|TimeNL||
 |ntppool2.time.nl|1|Netherlands|TimeNL||

--- a/chrony.conf
+++ b/chrony.conf
@@ -29,6 +29,7 @@ server ptbtime4.ptb.de nts iburst
 server www.jabber-germany.de nts iburst
 server www.masters-of-cloud.de nts iburst
 server ntp-by.dynu.net nts iburst
+server nts.ntstime.de nts iburst
 
 # TimeNL (Netherlands)
 server ntppool1.time.nl nts iburst


### PR DESCRIPTION
As owner and operator I would like to add my stratum 2 NTS server [nts.ntstime.de](https://nts.ntstime.de/) in Germany.