### PR TITLE
Add time.xargs.org server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following servers are known to be virtualized and may be less accurate. YMMV
 |Hostname|Stratum|Location|Owner|Notes|
 |---|:---:|---|---|---|
 |[ntp.viarouge.net](http://ntp.viarouge.net)|2|France|Hubert Viarouge||
+|time.xargs.org|2|US|Michael Driscoll|IPv4 and IPv6|
 
 ## Star History
 <a href="https://star-history.com/#jauderho/nts-servers&Timeline">

--- a/chrony.conf
+++ b/chrony.conf
@@ -70,3 +70,4 @@ server brazil.time.system76.com nts iburst
 server stratum1.time.cifelli.xyz nts iburst
 server time.cifelli.xyz nts iburst
 server time.txryan.com nts iburst
+server time.xargs.org nts iburst


### PR DESCRIPTION
# Description

Adds my time server (time.xargs.org) to the list.

This NTP server has been a part of the ntppool project for at least a decade now. It is virtualized but keeps time ±20ms, ref [its NTPPool page](https://www.ntppool.org/scores/52.6.191.28).

I've only set up NTS today, but it seems correct to my eyes:
```
$ openssl s_client -connect time.xargs.org:4460 -tlsextdebug -alpn 'ntske/1' -status < /dev/null
... snip ...
---
Certificate chain
 0 s:CN=xargs.org
   i:C=US, O=Let's Encrypt, CN=E5
   a:PKEY: id-ecPublicKey, 256 (bit); sigalg: ecdsa-with-SHA384
   v:NotBefore: Jun 25 18:18:09 2024 GMT; NotAfter: Sep 23 18:18:08 2024 GMT
 1 s:C=US, O=Let's Encrypt, CN=E5
   i:C=US, O=Internet Security Research Group, CN=ISRG Root X1
   a:PKEY: id-ecPublicKey, 384 (bit); sigalg: RSA-SHA256
   v:NotBefore: Mar 13 00:00:00 2024 GMT; NotAfter: Mar 12 23:59:59 2027 GMT
... snip ...
subject=CN=xargs.org
issuer=C=US, O=Let's Encrypt, CN=E5
---
... snip ...
Verify return code: 0 (ok)
---
DONE

```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 292cd386e5d7d4191bd3356745a3b7d69dffef52  | 
|--------|--------|

### Summary:
Added `time.xargs.org` NTP server to `README.md` and `chrony.conf`.

**Key points**:
- Added `time.xargs.org` to the list of NTP servers in `README.md`.
- Updated `chrony.conf` to include `time.xargs.org` with `nts iburst` configuration.
- `time.xargs.org` is a virtualized server located in the US, owned by Michael Driscoll, supporting both IPv4 and IPv6.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->