### PR TITLE
Update nts-sources.yml

### DIFF
--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -54,6 +54,12 @@ servers:
     owner: Cadu Silva
     vm: false
 
+  - hostname: "[time.web-clock.ca](https://time.web-clock.ca)"
+    stratum: 1
+    location: Canada
+    owner: Community
+    vm: false
+
   - hostname: "[ntp.miuku.net](https://ntp.miuku.net)"
     stratum: 3
     location: Finland


### PR DESCRIPTION
Added time.web-clock.ca server located in Canada
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `time.web-clock.ca` NTP server to `nts-sources.yml`, located in Canada, stratum 1, owned by Community.
> 
>   - **Behavior**:
>     - Added new NTP server `time.web-clock.ca` to `nts-sources.yml`.
>     - Server is located in Canada, stratum 1, owned by Community, and not a VM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fnts-servers&utm_source=github&utm_medium=referral)<sup> for be26beabc1ead25cf1a5b54fc88fe0c5d0840050. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->