### PR TITLE
Add Wiktel and MBIX NTS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |[stratum1.time.cifelli.xyz](https://stratum1.time.cifelli.xyz)|1|US|Mike Cifelli||
 |[time.cifelli.xyz](https://time.cifelli.xyz)|2|US|Mike Cifelli||
 |[time.txryan.com](https://time.txryan.com)|2|US|Tanner Ryan||
+|[ntp1.wiktel.com](https://ntp1.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|
+|[ntp2.wiktel.com](https://ntp2.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|
 
 The following servers are known to be virtualized and may be less accurate. YMMV.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |brazil.time.system76.com|2|Brazil|System76||
 |time.bolha.one|2|Brazil|Cadu Silva||
 ||
+|[time1.mbix.ca](https://time1.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
+|[time2.mbix.ca](https://time2.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
+|[time3.mbix.ca](https://time3.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
 |[time.web-clock.ca](https://time.web-clock.ca)|1|Canada|Community||
 ||
 |ntp.miuku.net|3|Finland|miuku.net||

--- a/chrony.conf
+++ b/chrony.conf
@@ -24,6 +24,9 @@ server brazil.time.system76.com nts iburst
 server time.bolha.one nts iburst
 
 # Canada
+server time1.mbix.ca nts iburst
+server time2.mbix.ca nts iburst
+server time3.mbix.ca nts iburst
 server time.web-clock.ca nts iburst
 
 # Finland

--- a/chrony.conf
+++ b/chrony.conf
@@ -85,6 +85,8 @@ server virginia.time.system76.com nts iburst
 server stratum1.time.cifelli.xyz nts iburst
 server time.cifelli.xyz nts iburst
 server time.txryan.com nts iburst
+server ntp1.wiktel.com nts iburst
+server ntp2.wiktel.com nts iburst
 
 # Known VM servers (may be less accurate)
 server ntp.viarouge.net nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -65,6 +65,18 @@ address = "time.bolha.one"
 # Canada
 [[source]]
 mode = "nts"
+address = "time1.mbix.ca"
+
+[[source]]
+mode = "nts"
+address = "time2.mbix.ca"
+
+[[source]]
+mode = "nts"
+address = "time3.mbix.ca"
+
+[[source]]
+mode = "nts"
 address = "time.web-clock.ca"
 
 

--- a/ntp.toml
+++ b/ntp.toml
@@ -253,6 +253,14 @@ address = "time.cifelli.xyz"
 mode = "nts"
 address = "time.txryan.com"
 
+[[source]]
+mode = "nts"
+address = "ntp1.wiktel.com"
+
+[[source]]
+mode = "nts"
+address = "ntp2.wiktel.com"
+
 
 # Known VM servers (may be less accurate)
 [[source]]

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -369,3 +369,17 @@ servers:
   owner: Michael Driscoll
   notes: IPv4 and IPv6
   vm: true
+
+- hostname: '[ntp1.wiktel.com](https://ntp1.wiktel.com)'
+  stratum: 1
+  location: US
+  owner: Wikstrom Telephone Company
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: '[ntp2.wiktel.com](https://ntp2.wiktel.com)'
+  stratum: 1
+  location: US
+  owner: Wikstrom Telephone Company
+  notes: IPv4 and IPv6
+  vm: false

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -82,6 +82,27 @@ servers:
   owner: Cadu Silva
   vm: false
 
+- hostname: '[time1.mbix.ca](https://time1.mbix.ca)'
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: '[time2.mbix.ca](https://time2.mbix.ca)'
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: '[time3.mbix.ca](https://time3.mbix.ca)'
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: IPv4 and IPv6
+  vm: false
+
 - hostname: '[time.web-clock.ca](https://time.web-clock.ca)'
   stratum: 1
   location: Canada


### PR DESCRIPTION
I am involved in administering these servers. (In the case of Wiktel, it's my day job. In the case of MBIX, it's a collaboration with them.) I certify that I have permission to add them to public lists.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add NTP servers from Manitoba Internet Exchange and Wikstrom Telephone Company to multiple configuration files for NTS support.
> 
>   - **Servers Added**:
>     - Added `time1.mbix.ca`, `time2.mbix.ca`, `time3.mbix.ca` for Manitoba Internet Exchange in Canada to `README.md`, `chrony.conf`, `ntp.toml`, and `nts-sources.yml`.
>     - Added `ntp1.wiktel.com`, `ntp2.wiktel.com` for Wikstrom Telephone Company in the US to `README.md`, `chrony.conf`, `ntp.toml`, and `nts-sources.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fnts-servers&utm_source=github&utm_medium=referral)<sup> for a69cd45651e859a42fa9499d32b3248ba308055d. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->