### PR TITLE
Add `0.ntp.bksp.in` for RU region

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |ntppool2.time.nl|1|Netherlands|TimeNL||
 |nts.decepticon.space|1|Netherlands|Rick Betting||
 ||
+|[0.ntp.bksp.in](https://0.ntp.bksp.in)|1|Russia|[B4CKSP4CE](https://bksp.in)||
+||
 |[ntpmon.dcs1.biz](https://ntpmon.dcs1.biz)|3|Singapore|Sanjeev Gupta||
 ||
 |nts.netnod.se|1|Sweden|Netnod|Anycast|

--- a/chrony.conf
+++ b/chrony.conf
@@ -62,6 +62,9 @@ server ntppool1.time.nl nts iburst
 server ntppool2.time.nl nts iburst
 server nts.decepticon.space nts iburst
 
+# Russia
+server 0.ntp.bksp.in nts iburst
+
 # Singapore
 server ntpmon.dcs1.biz nts iburst
 

--- a/ntp.toml
+++ b/ntp.toml
@@ -176,6 +176,12 @@ mode = "nts"
 address = "nts.decepticon.space"
 
 
+# Russia
+[[source]]
+mode = "nts"
+address = "0.ntp.bksp.in"
+
+
 # Singapore
 [[source]]
 mode = "nts"

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -321,6 +321,12 @@ servers:
   owner: Rick Betting
   vm: false
 
+- hostname: '[0.ntp.bksp.in](https://0.ntp.bksp.in)'
+  stratum: 1
+  location: Russia
+  owner: '[B4CKSP4CE](https://bksp.in)'
+  vm: false
+
 - hostname: '[ntpmon.dcs1.biz](https://ntpmon.dcs1.biz)'
   stratum: 3
   location: Singapore


### PR DESCRIPTION
Adding `0.ntp.bksp.in` as a S1 server in Russian Federation.

Thorough description is available at https://0.ntp.bksp.in, but here is an excerpt of the most relevant features:

- Stratum 1 with GNSS reference (GPS & GLO, aligned to GPST timescale).
- Trimble RES SMT 360 GNSS connected to Raspberry Pi 4 kernel PPS.
- Runs ntpd-rs.
- NTS-KE certificate automatic renewal & monitoring set.

NTS check log:

```
➜ ./scripts/ntsCheck.sh 0.ntp.bksp.in                    
2026-04-06T21:15:55Z chronyd version 4.8 starting (+CMDMON +REFCLOCK -RTC +PRIVDROP -SCFILTER -SIGND +NTS +SECHASH +IPV6 -DEBUG)
2026-04-06T21:15:55Z Disabled control of system clock
2026-04-06T21:15:57Z System clock wrong by 0.105807 seconds (ignored)
2026-04-06T21:15:57Z chronyd exiting
```