### PR TITLE
Add Nothing to hide NTS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |[www.masters-of-cloud.de](https://www.masters-of-cloud.de)|2|Germany|Jörg Morbitzer||
 |ntp.nanosrvr.cloud|1|Germany|Michael Byczkowski|IPv4 and IPv6|
 ||
+|1.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
+|2.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
+|3.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
+|4.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
 |ntppool1.time.nl|1|Netherlands|TimeNL||
 |ntppool2.time.nl|1|Netherlands|TimeNL||
 |nts.decepticon.space|1|Netherlands|Rick Betting||

--- a/chrony.conf
+++ b/chrony.conf
@@ -54,6 +54,10 @@ server www.masters-of-cloud.de nts iburst
 server ntp.nanosrvr.cloud nts iburst
 
 # Netherlands
+server 1.nts.nothingtohide.nl nts iburst
+server 2.nts.nothingtohide.nl nts iburst
+server 3.nts.nothingtohide.nl nts iburst
+server 4.nts.nothingtohide.nl nts iburst
 server ntppool1.time.nl nts iburst
 server ntppool2.time.nl nts iburst
 server nts.decepticon.space nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -149,6 +149,22 @@ address = "ntp.nanosrvr.cloud"
 # Netherlands
 [[source]]
 mode = "nts"
+address = "1.nts.nothingtohide.nl"
+
+[[source]]
+mode = "nts"
+address = "2.nts.nothingtohide.nl"
+
+[[source]]
+mode = "nts"
+address = "3.nts.nothingtohide.nl"
+
+[[source]]
+mode = "nts"
+address = "4.nts.nothingtohide.nl"
+
+[[source]]
+mode = "nts"
 address = "ntppool1.time.nl"
 
 [[source]]

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -275,6 +275,34 @@ servers:
   notes: IPv4 and IPv6
   vm: false
 
+- hostname: 1.nts.nothingtohide.nl
+  stratum: 2
+  location: Netherlands
+  owner: Nothing to hide
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: 2.nts.nothingtohide.nl
+  stratum: 2
+  location: Netherlands
+  owner: Nothing to hide
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: 3.nts.nothingtohide.nl
+  stratum: 2
+  location: Netherlands
+  owner: Nothing to hide
+  notes: IPv4 and IPv6
+  vm: false
+
+- hostname: 4.nts.nothingtohide.nl
+  stratum: 2
+  location: Netherlands
+  owner: Nothing to hide
+  notes: IPv4 and IPv6
+  vm: false
+
 - hostname: ntppool1.time.nl
   stratum: 1
   location: Netherlands


### PR DESCRIPTION
This PR adds four new high-capacity bare metal Stratum 2 NTS servers located in Amsterdam, Netherlands, provided by 'Nothing to hide'.

Changes:
- Added the servers to `nts-sources.yml`.
- Regenerated `README.md`, `chrony.conf`, and `ntp.toml` using `scripts/ntsServerConverter.py`.
- Verified connectivity for all four servers using `scripts/verifyNTSServers.py`.

Fixes #157

---
*PR created automatically by Jules for task [11447157751871976245](https://jules.google.com/task/11447157751871976245) started by @jauderho*