### PR TITLE
Reporting certificate lifetimes for NTS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,114 +29,115 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
   - `./scripts/ntsCheck.sh <NTS_SERVER_NAME>` 
 
 ## The List
-|Hostname|Stratum|Location|Owner|Notes|
-|---|:---:|---|---|---|
-|time.cloudflare.com|3|All|Cloudflare|Anycast|
+|Hostname|Stratum|Location|Owner|Notes|Cert Validity|
+|---|:---:|---|---|---|---|
+|time.cloudflare.com|3|All|Cloudflare|Anycast|1 year|
 ||
-|1.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|
-|2.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|
-|3.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|
-|4.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|
+|1.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|2.9 months|
+|ntp-bootstrap.ubuntu.com|2|Distro|Ubuntu|Self-signed certificate with long validity|130 years|
+|2.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|2.9 months|
+|3.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|2.9 months|
+|4.ntp.ubuntu.com|2|Distro|Ubuntu|Distro use only|2.9 months|
 ||
-|[nts.teambelgium.net](https://ntp.teambelgium.net)|1|Belgium|Team Belgium||
+|[nts.teambelgium.net](https://ntp.teambelgium.net)|1|Belgium|Team Belgium||2.9 months|
 ||
-|a.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||
-|b.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||
-|c.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||
-|d.st1.ntp.br|2|Brazil|[ntp.br](https://ntp.br)||
-|gps.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||
-|brazil.time.system76.com|2|Brazil|System76||
-|time.bolha.one|2|Brazil|Cadu Silva||
+|a.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||2.9 months|
+|b.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)|||
+|c.st1.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||2.9 months|
+|d.st1.ntp.br|2|Brazil|[ntp.br](https://ntp.br)||2.9 months|
+|gps.ntp.br|1|Brazil|[ntp.br](https://ntp.br)||2.9 months|
+|brazil.time.system76.com|2|Brazil|System76||2.9 months|
+|time.bolha.one|2|Brazil|Cadu Silva||2.9 months|
 ||
-|[time1.mbix.ca](https://time1.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
-|[time2.mbix.ca](https://time2.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
-|[time3.mbix.ca](https://time3.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|
-|[time.web-clock.ca](https://time.web-clock.ca)|1|Canada|Community||
+|[time1.mbix.ca](https://time1.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|2.9 months|
+|[time2.mbix.ca](https://time2.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|2.9 months|
+|[time3.mbix.ca](https://time3.mbix.ca)|1|Canada|Manitoba Internet Exchange|IPv4 and IPv6|2.9 months|
+|[time.web-clock.ca](https://time.web-clock.ca)|1|Canada|Community||2.9 months|
 ||
-|[nts1.ntp.hr](http://www.ntp.hr)|1|Croatia|UNIZG FER REMLAB|[rem.fer.hr](https://rem.fer.hr)|
-|[nts2.ntp.hr](http://www.ntp.hr)|1|Croatia|UNIZG FER REMLAB|[rem.fer.hr](https://rem.fer.hr)|
+|[nts1.ntp.hr](http://www.ntp.hr)|1|Croatia|UNIZG FER REMLAB|[rem.fer.hr](https://rem.fer.hr)|6.5 months|
+|[nts2.ntp.hr](http://www.ntp.hr)|1|Croatia|UNIZG FER REMLAB|[rem.fer.hr](https://rem.fer.hr)|6.5 months|
 ||
-|[time.cincura.net](https://time.cincura.net)|1|Czech Republic|Jiří Činčura|IPv4 and IPv6|
+|[time.cincura.net](https://time.cincura.net)|1|Czech Republic|Jiří Činčura|IPv4 and IPv6|2.9 months|
 ||
-|ntp.miuku.net|3|Finland|miuku.net||
+|ntp.miuku.net|3|Finland|miuku.net||2.9 months|
 ||
-|paris.time.system76.com|2|France|System76||
+|paris.time.system76.com|2|France|System76||2.9 months|
 ||
-|ntp3.fau.de|1|Germany|FAU||
-|ntp3.ipv6.fau.de|1|Germany|FAU|IPv6 only|
-|ptbtime1.ptb.de|1|Germany|PTB||
-|ptbtime2.ptb.de|1|Germany|PTB||
-|ptbtime3.ptb.de|1|Germany|PTB||
-|ptbtime4.ptb.de|1|Germany|PTB||
-|[www.jabber-germany.de](https://www.jabber-germany.de)|2|Germany|Jörg Morbitzer||
-|[www.masters-of-cloud.de](https://www.masters-of-cloud.de)|2|Germany|Jörg Morbitzer||
-|ntp.nanosrvr.cloud|1|Germany|Michael Byczkowski|IPv4 and IPv6|
+|ntp3.fau.de|1|Germany|FAU||2.9 months|
+|ntp3.ipv6.fau.de|1|Germany|FAU|IPv6 only||
+|ptbtime1.ptb.de|1|Germany|PTB||2.9 months|
+|ptbtime2.ptb.de|1|Germany|PTB||2.9 months|
+|ptbtime3.ptb.de|1|Germany|PTB||2.9 months|
+|ptbtime4.ptb.de|1|Germany|PTB||2.9 months|
+|[www.jabber-germany.de](https://www.jabber-germany.de)|2|Germany|Jörg Morbitzer||2.9 months|
+|[www.masters-of-cloud.de](https://www.masters-of-cloud.de)|2|Germany|Jörg Morbitzer||2.9 months|
+|ntp.nanosrvr.cloud|1|Germany|Michael Byczkowski|IPv4 and IPv6|2.9 months|
 ||
-|1.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
-|2.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
-|3.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
-|4.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|
-|ntppool1.time.nl|1|Netherlands|TimeNL||
-|ntppool2.time.nl|1|Netherlands|TimeNL||
-|nts.decepticon.space|1|Netherlands|Rick Betting||
+|1.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|2.9 months|
+|2.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|3 months|
+|3.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|3 months|
+|4.nts.nothingtohide.nl|2|Netherlands|Nothing to hide|IPv4 and IPv6|3 months|
+|ntppool1.time.nl|1|Netherlands|TimeNL||2.9 months|
+|ntppool2.time.nl|1|Netherlands|TimeNL||2.9 months|
+|nts.decepticon.space|1|Netherlands|Rick Betting||2.9 months|
 ||
-|[ntpmon.dcs1.biz](https://ntpmon.dcs1.biz)|3|Singapore|Sanjeev Gupta||
+|[ntpmon.dcs1.biz](https://ntpmon.dcs1.biz)|3|Singapore|Sanjeev Gupta||2.9 months|
 ||
-|nts.netnod.se|1|Sweden|Netnod|Anycast|
-|gbg1.nts.netnod.se|1|Sweden|Netnod|For users near Göteborg|
-|gbg2.nts.netnod.se|1|Sweden|Netnod|For users near Göteborg|
-|lul1.nts.netnod.se|1|Sweden|Netnod|For users near Luleå|
-|lul2.nts.netnod.se|1|Sweden|Netnod|For users near Luleå|
-|mmo1.nts.netnod.se|1|Sweden|Netnod|For users near Malmö|
-|mmo2.nts.netnod.se|1|Sweden|Netnod|For users near Malmö|
-|sth1.nts.netnod.se|1|Sweden|Netnod|For users near Stockholm|
-|sth2.nts.netnod.se|1|Sweden|Netnod|For users near Stockholm|
-|svl1.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
-|svl2.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
+|nts.netnod.se|1|Sweden|Netnod|Anycast||
+|gbg1.nts.netnod.se|1|Sweden|Netnod|For users near Göteborg|2.9 months|
+|gbg2.nts.netnod.se|1|Sweden|Netnod|For users near Göteborg|2.9 months|
+|lul1.nts.netnod.se|1|Sweden|Netnod|For users near Luleå|2.9 months|
+|lul2.nts.netnod.se|1|Sweden|Netnod|For users near Luleå|2.9 months|
+|mmo1.nts.netnod.se|1|Sweden|Netnod|For users near Malmö|2.9 months|
+|mmo2.nts.netnod.se|1|Sweden|Netnod|For users near Malmö|2.9 months|
+|sth1.nts.netnod.se|1|Sweden|Netnod|For users near Stockholm|2.9 months|
+|sth2.nts.netnod.se|1|Sweden|Netnod|For users near Stockholm|2.9 months|
+|svl1.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|2.9 months|
+|svl2.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|2.9 months|
 ||
-|[ntp.3eck.net](https://ntp.3eck.net)|3|Switzerland|Adrian Zaugg||
-|[ntp.trifence.ch](https://ntp.trifence.ch)|2|Switzerland|Marcel Waldvogel||
-|[ntp.zeitgitter.net](https://ntp.zeitgitter.net)|2|Switzerland|Marcel Waldvogel||
-|[ntp01.maillink.ch](https://ntp01.maillink.ch)|1|Switzerland|Ueli Heuer||
-|[ntp02.maillink.ch](https://ntp02.maillink.ch)|1|Switzerland|Ueli Heuer||
-|[ntp03.maillink.ch](https://ntp03.maillink.ch)|1|Switzerland|Ueli Heuer||
-|time.signorini.ch|1|Switzerland|Attilio Signorini||
+|[ntp.3eck.net](https://ntp.3eck.net)|3|Switzerland|Adrian Zaugg||2.9 months|
+|[ntp.trifence.ch](https://ntp.trifence.ch)|2|Switzerland|Marcel Waldvogel|||
+|[ntp.zeitgitter.net](https://ntp.zeitgitter.net)|2|Switzerland|Marcel Waldvogel|||
+|[ntp01.maillink.ch](https://ntp01.maillink.ch)|1|Switzerland|Ueli Heuer||2.9 months|
+|[ntp02.maillink.ch](https://ntp02.maillink.ch)|1|Switzerland|Ueli Heuer||2.9 months|
+|[ntp03.maillink.ch](https://ntp03.maillink.ch)|1|Switzerland|Ueli Heuer||2.9 months|
+|time.signorini.ch|1|Switzerland|Attilio Signorini|||
 ||
-|ntp2.glypnod.com|2|UK|Hal Murray|London|
-|ntp1.dmz.terryburton.co.uk|1|UK|Terry Burton|IPv4 and IPv6|
-|ntp2.dmz.terryburton.co.uk|1|UK|Terry Burton|IPv4 and IPv6|
-|ntp0.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|
-|ntp1.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|
-|ntp2.cam.ac.uk|2|UK|University of Cambridge, Department of Engineering|IPv4 and IPv6|
-|ntp3.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|
+|ntp2.glypnod.com|2|UK|Hal Murray|London|2.9 months|
+|ntp1.dmz.terryburton.co.uk|1|UK|Terry Burton|IPv4 and IPv6|2.9 months|
+|ntp2.dmz.terryburton.co.uk|1|UK|Terry Burton|IPv4 and IPv6|2.9 months|
+|ntp0.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|12 months|
+|ntp1.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|12 months|
+|ntp2.cam.ac.uk|2|UK|University of Cambridge, Department of Engineering|IPv4 and IPv6|12 months|
+|ntp3.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|12 months|
 ||
-|ntp1.glypnod.com|2|US|Hal Murray|San Francisco|
-|ohio.time.system76.com|2|US|System76||
-|oregon.time.system76.com|2|US|System76||
-|virginia.time.system76.com|2|US|System76||
-|[stratum1.time.cifelli.xyz](https://stratum1.time.cifelli.xyz)|1|US|Mike Cifelli||
-|[time.cifelli.xyz](https://time.cifelli.xyz)|2|US|Mike Cifelli||
-|[time.txryan.com](https://time.txryan.com)|2|US|Tanner Ryan||
-|[ntp1.wiktel.com](https://ntp1.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|
-|[ntp2.wiktel.com](https://ntp2.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|
+|ntp1.glypnod.com|2|US|Hal Murray|San Francisco|2.9 months|
+|ohio.time.system76.com|2|US|System76||2.9 months|
+|oregon.time.system76.com|2|US|System76||2.9 months|
+|virginia.time.system76.com|2|US|System76||2.9 months|
+|[stratum1.time.cifelli.xyz](https://stratum1.time.cifelli.xyz)|1|US|Mike Cifelli||2.9 months|
+|[time.cifelli.xyz](https://time.cifelli.xyz)|2|US|Mike Cifelli||2.9 months|
+|[time.txryan.com](https://time.txryan.com)|2|US|Tanner Ryan||2.9 months|
+|[ntp1.wiktel.com](https://ntp1.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|2.9 months|
+|[ntp2.wiktel.com](https://ntp2.wiktel.com)|1|US|Wikstrom Telephone Company|IPv4 and IPv6|2.9 months|
 
 The following servers are known to be virtualized and may be less accurate. YMMV.
 
-|Hostname|Stratum|Location|Owner|Notes|
-|---|:---:|---|---|---|
-|ntp.viarouge.net|2|France|Hubert Viarouge||
-|ntp1.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|
-|ntp10.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|
-|ntp11.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|TH2 Paris, IPv4 and IPv6|
-|ntp2.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|
-|ntp3.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|
-|ntp4.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|
-|ntp5.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|
-|ntp6.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|
-|ntp8.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|
-|ntp9.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|
-|ntp7.rdem-systems.com|2|Germany|[RDEM Systems](https://www.rdem-systems.com)|Frankfurt area, IPv4 and IPv6|
-|[time.xargs.org](https://time.xargs.org)|3|US|Michael Driscoll|IPv4 and IPv6|
+|Hostname|Stratum|Location|Owner|Notes|Cert Validity|
+|---|:---:|---|---|---|---|
+|ntp.viarouge.net|2|France|Hubert Viarouge||3 months|
+|ntp1.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|2.9 months|
+|ntp10.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|2.9 months|
+|ntp11.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|TH2 Paris, IPv4 and IPv6|2.9 months|
+|ntp2.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|2.9 months|
+|ntp3.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|2.9 months|
+|ntp4.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA3, IPv4 and IPv6|2.9 months|
+|ntp5.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|2.9 months|
+|ntp6.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|2.9 months|
+|ntp8.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA5, IPv4 and IPv6|2.9 months|
+|ntp9.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|2.9 months|
+|ntp7.rdem-systems.com|2|Germany|[RDEM Systems](https://www.rdem-systems.com)|Frankfurt area, IPv4 and IPv6|2.9 months|
+|[time.xargs.org](https://time.xargs.org)|3|US|Michael Driscoll|IPv4 and IPv6||
 
 ## Star History
 <a href="https://star-history.com/#jauderho/nts-servers&Timeline">

--- a/chrony.conf
+++ b/chrony.conf
@@ -7,6 +7,7 @@ server time.cloudflare.com nts iburst
 
 # Distro
 server 1.ntp.ubuntu.com nts iburst
+server ntp-bootstrap.ubuntu.com nts iburst
 server 2.ntp.ubuntu.com nts iburst
 server 3.ntp.ubuntu.com nts iburst
 server 4.ntp.ubuntu.com nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -15,6 +15,10 @@ address = "1.ntp.ubuntu.com"
 
 [[source]]
 mode = "nts"
+address = "ntp-bootstrap.ubuntu.com"
+
+[[source]]
+mode = "nts"
 address = "2.ntp.ubuntu.com"
 
 [[source]]

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -1,10 +1,12 @@
 servers:
+
 - hostname: time.cloudflare.com
   stratum: 3
   location: All
   owner: Cloudflare
   notes: Anycast
   vm: false
+  certificate_validity: 1 year
 
 - hostname: 1.ntp.ubuntu.com
   stratum: 2
@@ -12,6 +14,15 @@ servers:
   owner: Ubuntu
   notes: Distro use only
   vm: false
+  certificate_validity: 2.9 months
+
+- hostname: ntp-bootstrap.ubuntu.com
+  stratum: 2
+  location: Distro
+  owner: Ubuntu
+  notes: Self-signed certificate with long validity
+  vm: false
+  certificate_validity: 130 years
 
 - hostname: 2.ntp.ubuntu.com
   stratum: 2
@@ -19,6 +30,7 @@ servers:
   owner: Ubuntu
   notes: Distro use only
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: 3.ntp.ubuntu.com
   stratum: 2
@@ -26,6 +38,7 @@ servers:
   owner: Ubuntu
   notes: Distro use only
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: 4.ntp.ubuntu.com
   stratum: 2
@@ -33,18 +46,21 @@ servers:
   owner: Ubuntu
   notes: Distro use only
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[nts.teambelgium.net](https://ntp.teambelgium.net)'
   stratum: 1
   location: Belgium
   owner: Team Belgium
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: a.st1.ntp.br
   stratum: 1
   location: Brazil
   owner: '[ntp.br](https://ntp.br)'
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: b.st1.ntp.br
   stratum: 1
@@ -57,30 +73,35 @@ servers:
   location: Brazil
   owner: '[ntp.br](https://ntp.br)'
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: d.st1.ntp.br
   stratum: 2
   location: Brazil
   owner: '[ntp.br](https://ntp.br)'
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: gps.ntp.br
   stratum: 1
   location: Brazil
   owner: '[ntp.br](https://ntp.br)'
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: brazil.time.system76.com
   stratum: 2
   location: Brazil
   owner: System76
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: time.bolha.one
   stratum: 2
   location: Brazil
   owner: Cadu Silva
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time1.mbix.ca](https://time1.mbix.ca)'
   stratum: 1
@@ -88,6 +109,7 @@ servers:
   owner: Manitoba Internet Exchange
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time2.mbix.ca](https://time2.mbix.ca)'
   stratum: 1
@@ -95,6 +117,7 @@ servers:
   owner: Manitoba Internet Exchange
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time3.mbix.ca](https://time3.mbix.ca)'
   stratum: 1
@@ -102,12 +125,14 @@ servers:
   owner: Manitoba Internet Exchange
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time.web-clock.ca](https://time.web-clock.ca)'
   stratum: 1
   location: Canada
   owner: Community
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[nts1.ntp.hr](http://www.ntp.hr)'
   stratum: 1
@@ -115,6 +140,7 @@ servers:
   owner: UNIZG FER REMLAB
   notes: '[rem.fer.hr](https://rem.fer.hr)'
   vm: false
+  certificate_validity: 6.5 months
 
 - hostname: '[nts2.ntp.hr](http://www.ntp.hr)'
   stratum: 1
@@ -122,6 +148,7 @@ servers:
   owner: UNIZG FER REMLAB
   notes: '[rem.fer.hr](https://rem.fer.hr)'
   vm: false
+  certificate_validity: 6.5 months
 
 - hostname: '[time.cincura.net](https://time.cincura.net)'
   stratum: 1
@@ -129,94 +156,108 @@ servers:
   owner: Jiří Činčura
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp.miuku.net
   stratum: 3
   location: Finland
   owner: miuku.net
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: paris.time.system76.com
   stratum: 2
   location: France
   owner: System76
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp1.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA4, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA4, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp2.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA4, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA4, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp3.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA3, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA3, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp4.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA3, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA3, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp5.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA5, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA5, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp6.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA5, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA5, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp8.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA5, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA5, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp9.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA4, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA4, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp10.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Equinix PA3, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Equinix PA3, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp11.rdem-systems.com
   stratum: 2
   location: France
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "TH2 Paris, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: TH2 Paris, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ntp3.fau.de
   stratum: 1
   location: Germany
   owner: FAU
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp3.ipv6.fau.de
   stratum: 1
@@ -228,45 +269,52 @@ servers:
 - hostname: ntp7.rdem-systems.com
   stratum: 2
   location: Germany
-  owner: "[RDEM Systems](https://www.rdem-systems.com)"
-  notes: "Frankfurt area, IPv4 and IPv6"
+  owner: '[RDEM Systems](https://www.rdem-systems.com)'
+  notes: Frankfurt area, IPv4 and IPv6
   vm: true
+  certificate_validity: 2.9 months
 
 - hostname: ptbtime1.ptb.de
   stratum: 1
   location: Germany
   owner: PTB
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ptbtime2.ptb.de
   stratum: 1
   location: Germany
   owner: PTB
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ptbtime3.ptb.de
   stratum: 1
   location: Germany
   owner: PTB
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ptbtime4.ptb.de
   stratum: 1
   location: Germany
   owner: PTB
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[www.jabber-germany.de](https://www.jabber-germany.de)'
   stratum: 2
   location: Germany
   owner: Jörg Morbitzer
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[www.masters-of-cloud.de](https://www.masters-of-cloud.de)'
   stratum: 2
   location: Germany
   owner: Jörg Morbitzer
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp.nanosrvr.cloud
   stratum: 1
@@ -274,6 +322,7 @@ servers:
   owner: Michael Byczkowski
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: 1.nts.nothingtohide.nl
   stratum: 2
@@ -281,6 +330,7 @@ servers:
   owner: Nothing to hide
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: 2.nts.nothingtohide.nl
   stratum: 2
@@ -288,6 +338,7 @@ servers:
   owner: Nothing to hide
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 3 months
 
 - hostname: 3.nts.nothingtohide.nl
   stratum: 2
@@ -295,6 +346,7 @@ servers:
   owner: Nothing to hide
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 3 months
 
 - hostname: 4.nts.nothingtohide.nl
   stratum: 2
@@ -302,30 +354,35 @@ servers:
   owner: Nothing to hide
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 3 months
 
 - hostname: ntppool1.time.nl
   stratum: 1
   location: Netherlands
   owner: TimeNL
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntppool2.time.nl
   stratum: 1
   location: Netherlands
   owner: TimeNL
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: nts.decepticon.space
   stratum: 1
   location: Netherlands
   owner: Rick Betting
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntpmon.dcs1.biz](https://ntpmon.dcs1.biz)'
   stratum: 3
   location: Singapore
   owner: Sanjeev Gupta
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: nts.netnod.se
   stratum: 1
@@ -340,6 +397,7 @@ servers:
   owner: Netnod
   notes: For users near Göteborg
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: gbg2.nts.netnod.se
   stratum: 1
@@ -347,6 +405,7 @@ servers:
   owner: Netnod
   notes: For users near Göteborg
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: lul1.nts.netnod.se
   stratum: 1
@@ -354,6 +413,7 @@ servers:
   owner: Netnod
   notes: For users near Luleå
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: lul2.nts.netnod.se
   stratum: 1
@@ -361,6 +421,7 @@ servers:
   owner: Netnod
   notes: For users near Luleå
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: mmo1.nts.netnod.se
   stratum: 1
@@ -368,6 +429,7 @@ servers:
   owner: Netnod
   notes: For users near Malmö
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: mmo2.nts.netnod.se
   stratum: 1
@@ -375,6 +437,7 @@ servers:
   owner: Netnod
   notes: For users near Malmö
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: sth1.nts.netnod.se
   stratum: 1
@@ -382,6 +445,7 @@ servers:
   owner: Netnod
   notes: For users near Stockholm
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: sth2.nts.netnod.se
   stratum: 1
@@ -389,6 +453,7 @@ servers:
   owner: Netnod
   notes: For users near Stockholm
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: svl1.nts.netnod.se
   stratum: 1
@@ -396,6 +461,7 @@ servers:
   owner: Netnod
   notes: For users near Sundsvall
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: svl2.nts.netnod.se
   stratum: 1
@@ -403,12 +469,14 @@ servers:
   owner: Netnod
   notes: For users near Sundsvall
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntp.3eck.net](https://ntp.3eck.net)'
   stratum: 3
   location: Switzerland
   owner: Adrian Zaugg
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntp.trifence.ch](https://ntp.trifence.ch)'
   stratum: 2
@@ -427,18 +495,21 @@ servers:
   location: Switzerland
   owner: Ueli Heuer
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntp02.maillink.ch](https://ntp02.maillink.ch)'
   stratum: 1
   location: Switzerland
   owner: Ueli Heuer
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntp03.maillink.ch](https://ntp03.maillink.ch)'
   stratum: 1
   location: Switzerland
   owner: Ueli Heuer
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: time.signorini.ch
   stratum: 1
@@ -452,6 +523,7 @@ servers:
   owner: Hal Murray
   notes: London
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp1.dmz.terryburton.co.uk
   stratum: 1
@@ -459,6 +531,7 @@ servers:
   owner: Terry Burton
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp2.dmz.terryburton.co.uk
   stratum: 1
@@ -466,6 +539,7 @@ servers:
   owner: Terry Burton
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp0.cam.ac.uk
   stratum: 2
@@ -473,6 +547,7 @@ servers:
   owner: University of Cambridge, University Information Services (UIS)
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 12 months
 
 - hostname: ntp1.cam.ac.uk
   stratum: 2
@@ -480,6 +555,7 @@ servers:
   owner: University of Cambridge, University Information Services (UIS)
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 12 months
 
 - hostname: ntp2.cam.ac.uk
   stratum: 2
@@ -487,6 +563,7 @@ servers:
   owner: University of Cambridge, Department of Engineering
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 12 months
 
 - hostname: ntp3.cam.ac.uk
   stratum: 2
@@ -494,6 +571,7 @@ servers:
   owner: University of Cambridge, University Information Services (UIS)
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 12 months
 
 - hostname: ntp1.glypnod.com
   stratum: 2
@@ -501,48 +579,56 @@ servers:
   owner: Hal Murray
   notes: San Francisco
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ohio.time.system76.com
   stratum: 2
   location: US
   owner: System76
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: oregon.time.system76.com
   stratum: 2
   location: US
   owner: System76
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: virginia.time.system76.com
   stratum: 2
   location: US
   owner: System76
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[stratum1.time.cifelli.xyz](https://stratum1.time.cifelli.xyz)'
   stratum: 1
   location: US
   owner: Mike Cifelli
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time.cifelli.xyz](https://time.cifelli.xyz)'
   stratum: 2
   location: US
   owner: Mike Cifelli
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[time.txryan.com](https://time.txryan.com)'
   stratum: 2
   location: US
   owner: Tanner Ryan
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: ntp.viarouge.net
   stratum: 2
   location: France
   owner: Hubert Viarouge
   vm: true
+  certificate_validity: 3 months
 
 - hostname: '[time.xargs.org](https://time.xargs.org)'
   stratum: 3
@@ -557,6 +643,7 @@ servers:
   owner: Wikstrom Telephone Company
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months
 
 - hostname: '[ntp2.wiktel.com](https://ntp2.wiktel.com)'
   stratum: 1
@@ -564,3 +651,4 @@ servers:
   owner: Wikstrom Telephone Company
   notes: IPv4 and IPv6
   vm: false
+  certificate_validity: 2.9 months

--- a/scripts/ntsServerConverter.py
+++ b/scripts/ntsServerConverter.py
@@ -35,7 +35,7 @@ def _sort_key(server):
 
 def generate_markdown(data):
     markdown = "## The List\n"
-    markdown += "|Hostname|Stratum|Location|Owner|Notes|\n|---|:---:|---|---|---|\n"
+    markdown += "|Hostname|Stratum|Location|Owner|Notes|Cert Validity|\n|---|:---:|---|---|---|---|\n"
     current_location = None
     vm_servers = []
 
@@ -53,21 +53,23 @@ def generate_markdown(data):
         location = server["location"]
         owner = server["owner"]
         notes = server.get("notes", "")
+        validity = server.get("certificate_validity", "")
 
-        markdown += f"|{hostname}|{stratum}|{location}|{owner}|{notes}|\n"
+        markdown += f"|{hostname}|{stratum}|{location}|{owner}|{notes}|{validity}|\n"
 
     if vm_servers:
         vm_servers.sort(key=_sort_key)
         markdown += "\nThe following servers are known to be virtualized and may be less accurate. YMMV.\n\n"
-        markdown += "|Hostname|Stratum|Location|Owner|Notes|\n|---|:---:|---|---|---|\n"
+        markdown += "|Hostname|Stratum|Location|Owner|Notes|Cert Validity|\n|---|:---:|---|---|---|---|\n"
         for server in vm_servers:
             hostname = server["hostname"]
             stratum = server["stratum"]
             location = server["location"]
             owner = server["owner"]
             notes = server.get("notes", "")
+            validity = server.get("certificate_validity", "")
 
-            markdown += f"|{hostname}|{stratum}|{location}|{owner}|{notes}|\n"
+            markdown += f"|{hostname}|{stratum}|{location}|{owner}|{notes}|{validity}|\n"
 
     return markdown
 

--- a/scripts/ntsUpdateCertValidity.py
+++ b/scripts/ntsUpdateCertValidity.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "PyYAML",
+# ]
+# ///
+"""
+ntsUpdateCertValidity.py - Update certificate validity values in nts-sources.yml file
+
+This script reads an nts-sources.yml file, queries each hostname to get the current
+certificate validity using openssl, and updates the file with the values.
+"""
+
+import argparse
+import logging
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+import yaml
+
+
+def setup_logging(verbose=False):
+    """Setup logging configuration"""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+    return logging.getLogger(__name__)
+
+
+def extract_hostname(hostname_field):
+    """
+    Extract hostname from various formats:
+    - Plain text: "time.cloudflare.com"
+    - Markdown link: "[time.cloudflare.com](https://time.cloudflare.com)"
+    """
+    if not hostname_field:
+        return None
+
+    # Check if it's a markdown link format [text](url)
+    markdown_match = re.match(r'\[([^\]]+)\]', hostname_field)
+    if markdown_match:
+        return markdown_match.group(1)
+
+    # Otherwise, assume it's plain text
+    return hostname_field.strip()
+
+
+def get_cert_validity(hostname, logger):
+    """
+    Get certificate validity for a hostname using openssl
+    Returns the validity as string or None if not found
+    """
+    try:
+        # Step 1: Get raw certificates
+        cmd_s_client = [
+            'openssl', 's_client',
+            '-connect', f'{hostname}:4460',
+            '-showcerts',
+            '-servername', hostname
+        ]
+        s_client_proc = subprocess.Popen(
+            cmd_s_client,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True
+        )
+
+        # Step 2: Extract dates from certificate
+        cmd_x509 = ['openssl', 'x509', '-noout', '-dates']
+        x509_proc = subprocess.run(
+            cmd_x509,
+            input=s_client_proc.communicate(timeout=10)[0],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+
+        if x509_proc.returncode == 0:
+            dates = {}
+            for line in x509_proc.stdout.split('\n'):
+                if '=' in line:
+                    key, value = line.split('=', 1)
+                    dates[key] = value.strip()
+
+            if 'notBefore' in dates and 'notAfter' in dates:
+                # Format: Feb 17 21:30:57 2026 GMT
+                fmt = "%b %d %H:%M:%S %Y %Z"
+                try:
+                    start = datetime.strptime(dates['notBefore'], fmt)
+                    end = datetime.strptime(dates['notAfter'], fmt)
+                except ValueError:
+                    # Try without %Z just in case
+                    fmt_no_tz = "%b %d %H:%M:%S %Y"
+                    # Strip GMT/UTC from end
+                    start_str = ' '.join(dates['notBefore'].split()[:-1])
+                    end_str = ' '.join(dates['notAfter'].split()[:-1])
+                    start = datetime.strptime(start_str, fmt_no_tz)
+                    end = datetime.strptime(end_str, fmt_no_tz)
+
+                delta = end - start
+                days = delta.days
+
+                if days >= 365:
+                    years = round(days / 365.25, 1)
+                    if years == 1.0:
+                        return "1 year"
+                    if years == int(years):
+                        return f"{int(years)} years"
+                    return f"{years} years"
+                elif days >= 30:
+                    months = round(days / 30.44, 1)
+                    if months == 1.0:
+                        return "1 month"
+                    if months == int(months):
+                        return f"{int(months)} months"
+                    return f"{months} months"
+
+                if days == 1:
+                    return "1 day"
+                return f"{days} days"
+
+        logger.warning(f"Could not determine certificate validity for {hostname}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error getting certificate validity for {hostname}: {e}")
+        return None
+
+
+def load_yaml_file(filepath, logger):
+    """Load and parse YAML file"""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        logger.error(f"Error loading YAML file {filepath}: {e}")
+        return None
+
+
+def save_yaml_file(filepath, data, logger):
+    """Save data to YAML file with custom formatting"""
+    try:
+        # Dump with allow_unicode=True to preserve non-ASCII characters
+        yaml_content = yaml.dump(
+            data,
+            default_flow_style=False,
+            sort_keys=False,
+            indent=2,
+            allow_unicode=True
+        )
+
+        # Post-process to add blank lines between server entries
+        lines = yaml_content.split('\n')
+        formatted_lines = []
+
+        for i, line in enumerate(lines):
+            formatted_lines.append(line)
+            # Add blank line after entry if the next line starts with "- hostname:"
+            if i + 1 < len(lines) and lines[i + 1].strip().startswith('- hostname:'):
+                formatted_lines.append('')
+
+        # Write the formatted content
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(formatted_lines))
+
+        return True
+    except Exception as e:
+        logger.error(f"Error saving YAML file {filepath}: {e}")
+        return False
+
+
+def update_cert_values(data, logger, dry_run=False):
+    """
+    Update certificate validity values for all servers in the data
+    Returns tuple (updated_data, changes_made, total_servers)
+    """
+    if not data or 'servers' not in data:
+        logger.error("Invalid YAML structure: missing 'servers' key")
+        return data, False, 0
+
+    changes_made = False
+    total_servers = len(data['servers'])
+
+    logger.info(f"Processing {total_servers} servers...")
+
+    for i, server in enumerate(data['servers'], 1):
+        if 'hostname' not in server:
+            logger.warning(f"Server {i}: Missing hostname field")
+            continue
+
+        hostname_raw = server['hostname']
+        hostname = extract_hostname(hostname_raw)
+
+        if not hostname:
+            logger.warning(f"Server {i}: Could not extract hostname from '{hostname_raw}'")
+            continue
+
+        current_validity = server.get('certificate_validity', 'unknown')
+        logger.info(f"Server {i}/{total_servers}: Checking {hostname} (current validity: {current_validity})")
+
+        # Get actual validity
+        actual_validity = get_cert_validity(hostname, logger)
+
+        if actual_validity is None:
+            logger.warning(f"Server {i}: Could not determine certificate validity for {hostname}")
+            continue
+
+        # Compare and update if different
+        if current_validity != actual_validity:
+            if dry_run:
+                logger.info(f"Server {i}: [DRY RUN] Would update {hostname}: {current_validity} -> {actual_validity}")
+            else:
+                logger.info(f"Server {i}: Updating {hostname}: {current_validity} -> {actual_validity}")
+                server['certificate_validity'] = actual_validity
+            changes_made = True
+        else:
+            logger.info(f"Server {i}: {hostname} certificate validity is correct ({actual_validity})")
+
+    return data, changes_made, total_servers
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Update certificate validity values in nts-sources.yml file"
+    )
+    parser.add_argument(
+        'input_file',
+        nargs='?',
+        default='nts-sources.yml',
+        help='Input YAML file (default: nts-sources.yml)'
+    )
+    parser.add_argument(
+        '--output', '-o',
+        help='Output file (default: overwrite input file)'
+    )
+    parser.add_argument(
+        '--dry-run', '--dryrun',
+        action='store_true',
+        help='Show proposed changes without modifying the file'
+    )
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose logging'
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    logger = setup_logging(args.verbose)
+
+    # Check if input file exists
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        logger.error(f"Input file not found: {input_path}")
+        sys.exit(1)
+
+    # Determine output file
+    output_path = Path(args.output) if args.output else input_path
+
+    logger.info(f"Input file: {input_path}")
+    if args.dry_run:
+        logger.info("DRY RUN MODE - No changes will be made")
+    else:
+        logger.info(f"Output file: {output_path}")
+
+    # Load YAML data
+    logger.info("Loading YAML file...")
+    data = load_yaml_file(input_path, logger)
+    if data is None:
+        sys.exit(1)
+
+    # Update certificate validity values
+    updated_data, changes_made, total_servers = update_cert_values(data, logger, args.dry_run)
+
+    # Save results
+    if changes_made and not args.dry_run:
+        logger.info("Saving updated file...")
+        if save_yaml_file(output_path, updated_data, logger):
+            logger.info(f"Successfully updated {output_path}")
+        else:
+            logger.error("Failed to save updated file")
+            sys.exit(1)
+    elif changes_made and args.dry_run:
+        logger.info("DRY RUN: Changes would be made to the file")
+    else:
+        logger.info("No changes needed - all certificate validity values are correct")
+
+    logger.info(f"Processed {total_servers} servers")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Extended the NTS server list and maintenance scripts to report observed certificate lifetimes.

Key changes:
1.  **New Maintenance Script**: Added `scripts/ntsUpdateCertValidity.py` which uses `openssl s_client` to query the NTS port (4460) of each server and calculate its certificate validity period.
2.  **Updated Converter Script**: Modified `scripts/ntsServerConverter.py` to include the "Cert Validity" field in the generated `README.md` tables.
3.  **Bootstrap Server Addition**: Added `ntp-bootstrap.ubuntu.com` to `nts-sources.yml`. This server provides a self-signed certificate with a validity spanning 130 years, specifically intended for systems relying on disk-stored timestamps.
4.  **Data Refresh**: Updated `nts-sources.yml` with fetched validity data and regenerated all derived files (`README.md`, `chrony.conf`, `ntp.toml`).

These updates improve the utility of the list for admins managing hardware with no RTC (e.g., many embedded systems and Raspberry Pis).

Fixes #158

---
*PR created automatically by Jules for task [4613999865203117579](https://jules.google.com/task/4613999865203117579) started by @jauderho*