### PR TITLE
Add nts.amethyst.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |ntp2.cam.ac.uk|2|UK|University of Cambridge, Department of Engineering|IPv4 and IPv6|
 |ntp3.cam.ac.uk|2|UK|University of Cambridge, University Information Services (UIS)|IPv4 and IPv6|
 ||
+|nts.amethyst.name|2|US|Naomi Persephone Amethyst (AS53546)|Raleigh, NC|
 |ntp1.glypnod.com|2|US|Hal Murray|San Francisco|
 |ohio.time.system76.com|2|US|System76||
 |oregon.time.system76.com|2|US|System76||

--- a/chrony.conf
+++ b/chrony.conf
@@ -97,6 +97,7 @@ server ntp2.cam.ac.uk nts iburst
 server ntp3.cam.ac.uk nts iburst
 
 # US
+server nts.amethyst.name nts iburst
 server ntp1.glypnod.com nts iburst
 server ohio.time.system76.com nts iburst
 server oregon.time.system76.com nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -291,6 +291,10 @@ address = "ntp3.cam.ac.uk"
 # US
 [[source]]
 mode = "nts"
+address = "nts.amethyst.name"
+
+[[source]]
+mode = "nts"
 address = "ntp1.glypnod.com"
 
 [[source]]

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -495,6 +495,13 @@ servers:
   notes: IPv4 and IPv6
   vm: false
 
+- hostname: nts.amethyst.name
+  stratum: 2
+  location: US
+  owner: Naomi Persephone Amethyst (AS53546)
+  notes: Raleigh, NC
+  vm: false
+
 - hostname: ntp1.glypnod.com
   stratum: 2
   location: US


### PR DESCRIPTION
Adds new public Network Time Security (NTS) server, nts.amethyst.name, to the repository's configuration files and documentation.

This is a stratum 2 time server located in Raleigh, NC (US), operated by me (at AS53546).