### PR TITLE
Add mirror.mdapi.ch (Switzerland, stratum 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |svl1.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
 |svl2.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
 ||
-|mirror.mdapi.ch|2|Switzerland|Martino Dell'Ambrogio||
+|mirror.mdapi.ch|1|Switzerland|Martino Dell'Ambrogio||
 |[ntp.3eck.net](https://ntp.3eck.net)|3|Switzerland|Adrian Zaugg||
 |[ntp.trifence.ch](https://ntp.trifence.ch)|2|Switzerland|Marcel Waldvogel||
 |[ntp.zeitgitter.net](https://ntp.zeitgitter.net)|2|Switzerland|Marcel Waldvogel||

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This is intended to bootstrap a list of NTP servers with NTS support given that 
 |svl1.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
 |svl2.nts.netnod.se|1|Sweden|Netnod|For users near Sundsvall|
 ||
+|mirror.mdapi.ch|2|Switzerland|Martino Dell'Ambrogio||
 |[ntp.3eck.net](https://ntp.3eck.net)|3|Switzerland|Adrian Zaugg||
 |[ntp.trifence.ch](https://ntp.trifence.ch)|2|Switzerland|Marcel Waldvogel||
 |[ntp.zeitgitter.net](https://ntp.zeitgitter.net)|2|Switzerland|Marcel Waldvogel||

--- a/chrony.conf
+++ b/chrony.conf
@@ -86,6 +86,7 @@ server svl1.nts.netnod.se nts iburst
 server svl2.nts.netnod.se nts iburst
 
 # Switzerland
+server mirror.mdapi.ch nts iburst
 server ntp.3eck.net nts iburst
 server ntp.trifence.ch nts iburst
 server ntp.zeitgitter.net nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -247,6 +247,10 @@ address = "svl2.nts.netnod.se"
 # Switzerland
 [[source]]
 mode = "nts"
+address = "mirror.mdapi.ch"
+
+[[source]]
+mode = "nts"
 address = "ntp.3eck.net"
 
 [[source]]

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -422,6 +422,12 @@ servers:
   notes: For users near Sundsvall
   vm: false
 
+- hostname: mirror.mdapi.ch
+  stratum: 2
+  location: Switzerland
+  owner: Martino Dell'Ambrogio
+  vm: false
+
 - hostname: '[ntp.3eck.net](https://ntp.3eck.net)'
   stratum: 3
   location: Switzerland

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -423,7 +423,7 @@ servers:
   vm: false
 
 - hostname: mirror.mdapi.ch
-  stratum: 2
+  stratum: 1
   location: Switzerland
   owner: Martino Dell'Ambrogio
   vm: false


### PR DESCRIPTION
Adds `mirror.mdapi.ch`, a public NTS-enabled NTP server in Switzerland.

- chrony, stratum 2, NTS-KE on the default port 4460, Let's Encrypt certificate
- Dual-stack (IPv4 + IPv6)
- Verified reachable over NTS (key establishment + authenticated NTP) and plain NTP from off-network

Added to `nts-sources.yml` in the Switzerland section (kept alphabetical); `README.md`, `chrony.conf`, and `ntp.toml` regenerated with `scripts/ntsServerConverter.py` per `AGENTS.md`.
