### PR TITLE
Add beatquantum.com (UK) running Pure/Hybrid PQC NTS-KE

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The following servers are known to be virtualized and may be less accurate. YMMV
 |ntp9.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|
 |ntp7.rdem-systems.com|2|Germany|[RDEM Systems](https://www.rdem-systems.com)|Frankfurt area, IPv4 and IPv6|
 |solarium.stellata.ch|2|Switzerland|stellata.ch||
-|beatquantum.com|2|UK|BeatQuantum|IPv4 and IPv6|
+|beatquantum.com|2|UK|BeatQuantum|IPv4 and IPv6, Pure/Hybrid PQC NTS-KE|
 |[time.xargs.org](https://time.xargs.org)|3|US|Michael Driscoll|IPv4 and IPv6|
 
 ## Star History

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The following servers are known to be virtualized and may be less accurate. YMMV
 |ntp9.rdem-systems.com|2|France|[RDEM Systems](https://www.rdem-systems.com)|Equinix PA4, IPv4 and IPv6|
 |ntp7.rdem-systems.com|2|Germany|[RDEM Systems](https://www.rdem-systems.com)|Frankfurt area, IPv4 and IPv6|
 |solarium.stellata.ch|2|Switzerland|stellata.ch||
+|beatquantum.com|2|UK|BeatQuantum|IPv4 and IPv6|
 |[time.xargs.org](https://time.xargs.org)|3|US|Michael Driscoll|IPv4 and IPv6|
 
 ## Star History

--- a/chrony.conf
+++ b/chrony.conf
@@ -130,4 +130,5 @@ server ntp8.rdem-systems.com nts iburst
 server ntp9.rdem-systems.com nts iburst
 server ntp7.rdem-systems.com nts iburst
 server solarium.stellata.ch nts iburst
+server beatquantum.com nts iburst
 server time.xargs.org nts iburst

--- a/ntp.toml
+++ b/ntp.toml
@@ -405,5 +405,9 @@ address = "solarium.stellata.ch"
 
 [[source]]
 mode = "nts"
+address = "beatquantum.com"
+
+[[source]]
+mode = "nts"
 address = "time.xargs.org"
 

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -480,7 +480,7 @@ servers:
   stratum: 2
   location: UK
   owner: BeatQuantum
-  notes: IPv4 and IPv6
+  notes: IPv4 and IPv6, Pure/Hybrid PQC NTS-KE
   vm: true
 
 - hostname: ntp2.glypnod.com

--- a/nts-sources.yml
+++ b/nts-sources.yml
@@ -476,6 +476,13 @@ servers:
   owner: Attilio Signorini
   vm: false
 
+- hostname: beatquantum.com
+  stratum: 2
+  location: UK
+  owner: BeatQuantum
+  notes: IPv4 and IPv6
+  vm: true
+
 - hostname: ntp2.glypnod.com
   stratum: 2
   location: UK


### PR DESCRIPTION
Adding beatquantum.com, a stratum 2 NTS server in Coventry, United Kingdom, running NTPsec with PQC.

- NTS-KE on TCP 4460, IPv4 and IPv6 both verified (openssl -alpn ntske/1 handshake OK on both stacks; Let's Encrypt certificate with auto-renewal)
- NTS-KE TLS 1.3 supports post-quantum key exchange: pure PQC (ML-KEM, HQC, BIKE, FrodoKEM), hybrid PQC (e.g. X25519MLKEM768), and classical groups for fallback. AFAICS it is the world's first PQC KEM based NTS server and uses algorithms approved across multiple jurisdictions.
- scripts/ntsCheck.sh passes from an external network (Frankfurt, DE)
- Server is a cloud VPS, so it is marked vm: true and placed in the virtualized table. Observed performance from an external chrony client monitoring it alongside the existing UK entries: offset within ±0.5 ms of consensus and sample Std Dev in the 80-270 µs range, comparable to the currently listed UK servers.
- Files regenerated with scripts/ntsServerConverter.py